### PR TITLE
Add a rgw name check to prevent non-ascii rgw name

### DIFF
--- a/ceph_deploy/rgw.py
+++ b/ceph_deploy/rgw.py
@@ -152,7 +152,6 @@ def rgw_create(args):
     errors = 0
     for hostname, name in args.rgw:
         try:
-            name = validate.alphanumeric(name)
             distro = hosts.get(hostname, username=args.username)
             rlogger = distro.conn.logger
             LOG.info(
@@ -210,8 +209,12 @@ def colon_separated(s):
     name = s
     if s.count(':') == 1:
         (host, name) = s.split(':')
-    name = 'rgw.' + name
-    return (host, name)
+    try:
+        name = validate.alphanumeric(name)
+        name = 'rgw.' + name
+        return (host, name)
+    except ArgumentTypeError as e:
+        LOG.error(e)
 
 
 @priority(30)

--- a/ceph_deploy/rgw.py
+++ b/ceph_deploy/rgw.py
@@ -9,6 +9,7 @@ from ceph_deploy import hosts
 from ceph_deploy.util import system
 from ceph_deploy.lib import remoto
 from ceph_deploy.cliutil import priority
+from ceph_deploy import validate
 
 
 LOG = logging.getLogger(__name__)
@@ -151,6 +152,7 @@ def rgw_create(args):
     errors = 0
     for hostname, name in args.rgw:
         try:
+            name = validate.alphanumeric(name)
             distro = hosts.get(hostname, username=args.username)
             rlogger = distro.conn.logger
             LOG.info(


### PR DESCRIPTION
Just check the rgw name when it is being create to make sure we have ascii name. 
