### PR TITLE
Add a rgw name check to prevent non-ascii rgw name

### DIFF
--- a/ceph_deploy/rgw.py
+++ b/ceph_deploy/rgw.py
@@ -428,7 +428,7 @@ def colon_separated(s):
     if delimiter_count == 2:
         (host, name, port) = s.split(':')
     
-    name = validate.alphanumeric(name)
+    name = validate.alphanumericdot(name)
     return (host, name, port)
 
 

--- a/ceph_deploy/rgw.py
+++ b/ceph_deploy/rgw.py
@@ -9,6 +9,7 @@ from ceph_deploy import hosts
 from ceph_deploy.util import system
 from ceph_deploy.lib import remoto
 from ceph_deploy.cliutil import priority
+from ceph_deploy import validate
 
 
 LOG = logging.getLogger(__name__)
@@ -404,6 +405,7 @@ def colon_separated(s):
     name = 'rgw.' + s
     if s.count(':') == 1:
         (host, name) = s.split(':')
+    name = validate.alphanumeric(name)
     return (host, name)
 
 

--- a/ceph_deploy/validate.py
+++ b/ceph_deploy/validate.py
@@ -3,6 +3,7 @@ import re
 
 
 ALPHANUMERIC_RE = re.compile(r'^[a-zA-Z][a-zA-Z0-9]*$')
+ALPHANUMERICDOT_RE = re.compile(r'^[a-zA-Z][a-zA-Z0-9\.]*$')
 
 
 def alphanumeric(s):
@@ -12,5 +13,15 @@ def alphanumeric(s):
     if not ALPHANUMERIC_RE.match(s):
         raise argparse.ArgumentTypeError(
             'argument must start with a letter and contain only letters and numbers',
+            )
+    return s
+
+def alphanumericdot(s):
+    """
+    Enforces string to be alphanumeric and dot allowed with leading alpha.
+    """
+    if not ALPHANUMERICDOT_RE.match(s):
+        raise argparse.ArgumentTypeError(
+            'argument must start with a letter and contain only letters and numbers or dot',
             )
     return s


### PR DESCRIPTION
Just check the rgw name when it is being create to make sure we have ascii name.

Signed-off-by: Alex Lau (AvengerMoJo) alau@suse.com
