### PR TITLE
zypper remove each package separately

### DIFF
--- a/ceph_deploy/util/pkg_managers.py
+++ b/ceph_deploy/util/pkg_managers.py
@@ -295,22 +295,22 @@ class Zypper(PackageManager):
     def remove(self, packages, **kw):
         if isinstance(packages, str):
             packages = [packages]
-
-        extra_flags = kw.pop('extra_remove_flags', None)
-        cmd = self.executable + ['remove']
-        if extra_flags:
-            if isinstance(extra_flags, str):
-                extra_flags = [extra_flags]
-            cmd.extend(extra_flags)
-        cmd.extend(packages)
-        stdout, stderr, exitrc = remoto.process.check(
-            self.remote_conn,
-            cmd,
-            **kw
-        )
-        # exitrc is 104 when package(s) not installed.
-        if not exitrc in [0, 104]:
-            raise RuntimeError("Failed to execute command: %s" % " ".join(cmd))
+        for pkg in packages:
+            extra_flags = kw.pop('extra_remove_flags', None)
+            cmd = self.executable + ['remove']
+            if extra_flags:
+                if isinstance(extra_flags, str):
+                    extra_flags = [extra_flags]
+                cmd.extend(extra_flags)
+            cmd.append(pkg)
+            stdout, stderr, exitrc = remoto.process.check(
+                self.remote_conn,
+                cmd,
+                **kw
+            )
+            # exitrc is 104 when package(s) not installed.
+            if not exitrc in [0, 104]:
+                raise RuntimeError("Failed to execute command: %s" % " ".join(cmd))
         return
 
     def clean(self):


### PR DESCRIPTION
We ca not remove multiple packages with zypper in one line. as if a package is
not available in a repository, zypper will abort immediately rather than remove
the packages it was instructed to remove.

Signed-off-by:  Owen Synge osynge@suse.com
