### PR TITLE
zypper remove each package separately

### DIFF
--- a/ceph_deploy/util/pkg_managers.py
+++ b/ceph_deploy/util/pkg_managers.py
@@ -147,26 +147,25 @@ def zypper(conn, packages, *a, **kw):
 
 
 def zypper_remove(conn, packages, *a, **kw):
-    cmd = [
-        'zypper',
-        '--non-interactive',
-        '--quiet',
-        'remove',
-        ]
-
-    if isinstance(packages, str):
-        cmd.append(packages)
-    else:
-        cmd.extend(packages)
-    stdout, stderr, exitrc = remoto.process.check(
-        conn,
-        cmd,
-        *a,
-        **kw
-    )
-    # exitrc is 104 when package(s) not installed.
-    if not exitrc in [0, 104]:
-        raise RuntimeError("Failed to execute command: %s" % " ".join(cmd))
+    if not isinstance(packages, list):
+        packages = [packages]
+    for pkg in packages:
+        cmd = [
+            'zypper',
+            '--non-interactive',
+            '--quiet',
+            'remove',
+            ]
+        cmd.append(pkg)
+        stdout, stderr, exitrc = remoto.process.check(
+            conn,
+            cmd,
+            **kw
+        )
+        # exitrc is 104 when package(s) not installed.
+        if not exitrc in [0, 104]:
+            raise RuntimeError("Failed to execute command: %s" % " ".join(cmd))
+    return
 
 
 def zypper_refresh(conn):


### PR DESCRIPTION
We can not remove multiple packages with zypper in one line. as if a package is
not available in a repository, zypper will abort immediately rather than remove
the packages it was instructed to remove.

Signed-off-by:  Owen Synge osynge@suse.com
