### PR TITLE
Support `ceph-deploy calamari` on SLES without minion repo

### DIFF
--- a/ceph_deploy/calamari.py
+++ b/ceph_deploy/calamari.py
@@ -4,6 +4,30 @@ import os
 from ceph_deploy import hosts, exc
 from ceph_deploy.lib import remoto
 
+#
+# For use on SLES, `ceph-deploy calamari` doesn't use a calamari minion repo.
+# Rather, it relies on your Ceph nodes already having access to a respository
+# that containts salt-minion and its dependencies, as well as diamond, which
+# salt-minion will in turn install.  This completely removes any need to
+# specify repos, or alter your ~/.cephdeploy.conf file at all (which is what
+# (http://calamari.readthedocs.org/en/latest/operations/minion_connect.html
+# says you need to do).
+#
+# All you need to do to hook some set of Ceph nodes up to a calamari instance
+# is run:
+#
+#   ceph-deploy calamari connect --master <calamari-fqdn> <node1> [<node2> ...]
+#
+# For example:
+#
+#   ceph-deploy calamari connect --master calamari.example.com \
+#       ceph-0.example.com ceph-1.example.com ceph-2.example.com
+#
+# Or, if you are running ceph-deploy from your calamari host:
+#
+#   ceph-deploy calamari connect --master $(hostname -f) \
+#       ceph-0.example.com ceph-1.example.com ceph-2.example.com
+#
 
 LOG = logging.getLogger(__name__)
 
@@ -13,7 +37,7 @@ def distro_is_supported(distro_name):
     An enforcer of supported distros that can differ from what ceph-deploy
     supports.
     """
-    supported = ['centos', 'redhat', 'ubuntu', 'debian']
+    supported = ['suse']
     if distro_name in supported:
         return True
     return False
@@ -24,7 +48,7 @@ def connect(args):
         distro = hosts.get(hostname, username=args.username)
         if not distro_is_supported(distro.normalized_name):
             raise exc.UnsupportedPlatform(
-                distro.distro_name,
+                distro.name,
                 distro.codename,
                 distro.release
             )
@@ -39,6 +63,7 @@ def connect(args):
         LOG.info('Refer to the docs for examples (http://ceph.com/ceph-deploy/docs/conf.html)')
 
         rlogger = logging.getLogger(hostname)
+        rlogger.info('installing calamari-minion package on %s' % hostname)
 
         # Emplace minion config prior to installation so that it is present
         # when the minion first starts.
@@ -59,17 +84,15 @@ def connect(args):
         distro.packager.install('salt-minion')
         distro.packager.install('diamond')
 
-        # redhat/centos need to get the service started
-        if distro.normalized_name in ['redhat', 'centos']:
-            remoto.process.run(
-                distro.conn,
-                ['chkconfig', 'salt-minion', 'on']
-            )
+        remoto.process.run(
+            distro.conn,
+            ['systemctl', 'enable', 'salt-minion']
+        )
 
-            remoto.process.run(
-                distro.conn,
-                ['service', 'salt-minion', 'start']
-            )
+        remoto.process.run(
+            distro.conn,
+            ['systemctl', 'start', 'salt-minion']
+        )
 
         distro.conn.exit()
 
@@ -94,9 +117,8 @@ def make(parser):
     )
     calamari_connect.add_argument(
         '--master',
-        nargs='?',
-        metavar='MASTER SERVER',
-        help="The domain for the Calamari master server"
+        required=True,
+        help="The fully qualified domain name of the Calamari server"
     )
     calamari_connect.add_argument(
         'hosts',

--- a/ceph_deploy/tests/parser/test_calamari.py
+++ b/ceph_deploy/tests/parser/test_calamari.py
@@ -32,17 +32,25 @@ class TestParserCalamari(object):
         assert_too_few_arguments(err)
 
     def test_calamari_connect_one_host(self):
-        args = self.parser.parse_args('calamari connect host1'.split())
+        args = self.parser.parse_args('calamari connect --master master.ceph.com host1'.split())
         assert args.hosts == ['host1']
 
     def test_calamari_connect_multiple_hosts(self):
         hostnames = ['host1', 'host2', 'host3']
-        args = self.parser.parse_args('calamari connect'.split() + hostnames)
+        args = self.parser.parse_args('calamari connect --master master.ceph.com'.split() + hostnames)
         assert args.hosts == hostnames
 
-    def test_calamari_connect_master_default_is_none(self):
-        args = self.parser.parse_args('calamari connect host1'.split())
-        assert args.master is None
+    def test_calamari_connect_master_argument_is_required(self, capsys):
+        with pytest.raises(SystemExit):
+            self.parser.parse_args('calamari connect host1'.split())
+        out, err = capsys.readouterr()
+        # This is a little sloppy; python 2.x prints "argument --master is required"
+        # whereas python 3.x prints "the following arguments are required: --master"
+        # so we test that there's some error output that includes usage information
+        # and mentions "--master" and "required" :-/
+        assert 'usage: ceph-deploy calamari' in err
+        assert '--master' in err
+        assert 'required' in err
 
     def test_calamari_connect_master_custom(self):
         args = self.parser.parse_args('calamari connect --master master.ceph.com host1'.split())

--- a/ceph_deploy/tests/unit/test_calamari.py
+++ b/ceph_deploy/tests/unit/test_calamari.py
@@ -6,12 +6,12 @@ class TestDistroIsSupported(object):
 
     @pytest.mark.parametrize(
         "distro_name",
-        ['centos', 'redhat', 'ubuntu', 'debian'])
+        ['suse'])
     def test_distro_is_supported(self, distro_name):
         assert calamari.distro_is_supported(distro_name) is True
 
     @pytest.mark.parametrize(
         "distro_name",
-        ['fedora', 'mandriva', 'darwin', 'windows'])
+        ['centos', 'redhat', 'ubuntu', 'debian', 'fedora', 'mandriva', 'darwin', 'windows'])
     def test_distro_is_not_supported(self, distro_name):
         assert calamari.distro_is_supported(distro_name) is False


### PR DESCRIPTION
For use on SLES, `ceph-deploy calamari` doesn't use a calamari minion repo.
Rather, it relies on your Ceph nodes already having access to a respository
that containts salt-minion and its dependencies, as well as diamond, which
salt-minion will in turn install.  This completely removes any need to
specify repos, or alter your ~/.cephdeploy.conf file at all (which is what
(http://calamari.readthedocs.org/en/latest/operations/minion_connect.html
says you need to do).

This was cherry picked from commit 257bbb7426642d1ecdae42e8f8c0231e9af69ae4
then further updated so as to not break tests/parser/test_calamari.py

Signed-off-by: Tim Serong <tserong@suse.com>